### PR TITLE
adding spectral linter config

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,3 @@
+extends: spectral:oas
+rules:
+  path-keys-no-trailing-slash: error

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This repository stores the contracts for the [Order UI](http://github.com/znsio/specmatic-order-ui) client project and the [Order API](http://github.com/znsio/specmatic-order-api).
 
 The [api_order_v1.yaml](https://github.com/znsio/specmatic-order-contracts/blob/main/in/specmatic/examples/store/api_order_v1.yaml) contract in this repository governs the integration of the client and API.
+
+
+# Linting
+
+* Install [spectral](https://github.com/stoplightio/spectral#-installation-and-usage)
+* Run below command inside the repo
+```
+spectral lint **/*.yaml 
+```
+* Above command leverages .spectral.yaml


### PR DESCRIPTION
adding spectral linter config

How to test?
* Run spectral linter ```spectral lint in/specmatic/examples/store/api_order_v1.yaml```
* There should be no errors and ```echo $?``` should return 0 indicating that lint was success
* I have upgrade rule to disallow trailing slashes from warning to error in .spectral.yaml
* Add a trialing slash to any path in in/specmatic/examples/store/api_order_v1.yaml
* Run spectral linter ```spectral lint in/specmatic/examples/store/api_order_v1.yaml``` again
* Now an error will be displayed along with the warnings and ```echo $?``` should return 1 indicating lint error
