### PR TITLE
Refactoring order_api_v3.yaml

### DIFF
--- a/in/specmatic/examples/store/api_order_v3.yaml
+++ b/in/specmatic/examples/store/api_order_v3.yaml
@@ -39,11 +39,7 @@ paths:
                     inventory: 10
                     id: 10
         "400":
-          description: "Bad Request"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
         "404":
           description: "Not Found"
           content:
@@ -74,11 +70,7 @@ paths:
                 UPDATE_DETAILS:
                   value: "success"
         "400":
-          description: "Bad Request"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
       requestBody:
         content:
           application/json:
@@ -107,11 +99,7 @@ paths:
                 DELETE_PRODUCT:
                   value: "success"
         "400":
-          description: "Bad Request"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
   /products:
     get:
       summary: GET Products based on type
@@ -151,11 +139,7 @@ paths:
               schema:
                 $ref: "common.yaml#/components/schemas/ProductId"
         "400":
-          description: POST /products
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
   /orders:
     post:
       summary: POST /orders
@@ -184,11 +168,7 @@ paths:
                   value:
                     id: 10
         "400":
-          description: POST /orders
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
     get:
       summary: Search for orders
       operationId: get-orders
@@ -209,11 +189,7 @@ paths:
                       status: "pending"
                       id: 10
         "400":
-          description: "Bad Request"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
       parameters:
         - schema:
             type: number
@@ -260,11 +236,7 @@ paths:
                     status: "pending"
                     id: 10
         "400":
-          description: "Bad Request"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
         "404":
           description: "Not Found"
           content:
@@ -296,11 +268,7 @@ paths:
                 UPDATE_ORDER:
                   value: "success"
         "400":
-          description: "Bad Request"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
       requestBody:
         content:
           application/json:
@@ -329,11 +297,7 @@ paths:
                 DELETE_ORDER:
                   value: "success"
         "400":
-          description: "Bad Request"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+          $ref: "./common_responses.yaml#/components/responses/BadRequest"
 components:
   schemas:
     Products_RequestBody:

--- a/in/specmatic/examples/store/common.yaml
+++ b/in/specmatic/examples/store/common.yaml
@@ -74,16 +74,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/OrderId'
         - $ref: '#/components/schemas/OrderDetails'
-    BadRequestErrorResponseBody:
-      properties:
-        timestamp:
-          type: string
-        status:
-          type: number
-        error:
-          type: string
-        message:
-          type: string
   parameters:
     OrderStatusParam:
       name: OrderStatusParam

--- a/in/specmatic/examples/store/common.yaml
+++ b/in/specmatic/examples/store/common.yaml
@@ -74,6 +74,16 @@ components:
       allOf:
         - $ref: '#/components/schemas/OrderId'
         - $ref: '#/components/schemas/OrderDetails'
+    BadRequestErrorResponseBody:
+      properties:
+        timestamp:
+          type: string
+        status:
+          type: number
+        error:
+          type: string
+        message:
+          type: string
   parameters:
     OrderStatusParam:
       name: OrderStatusParam

--- a/in/specmatic/examples/store/common_response_schema.yaml
+++ b/in/specmatic/examples/store/common_response_schema.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Common schema
+  version: '1.0'
+paths: {}
+components:
+  schemas:
+    BadRequestErrorResponseBody:
+      properties:
+        timestamp:
+          type: string
+        status:
+          type: number
+        error:
+          type: string
+        message:
+          type: string

--- a/in/specmatic/examples/store/common_response_schema.yaml
+++ b/in/specmatic/examples/store/common_response_schema.yaml
@@ -6,6 +6,8 @@ paths: {}
 components:
   schemas:
     BadRequestErrorResponseBody:
+      required:
+        - error
       properties:
         timestamp:
           type: string

--- a/in/specmatic/examples/store/common_responses.yaml
+++ b/in/specmatic/examples/store/common_responses.yaml
@@ -10,4 +10,4 @@ components:
       content:
         application/json:
           schema:
-            $ref: "./common.yaml#/components/schemas/BadRequestErrorResponseBody"
+            $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"

--- a/in/specmatic/examples/store/common_responses.yaml
+++ b/in/specmatic/examples/store/common_responses.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+info:
+  title: Common schema
+  version: '1.0'
+paths: {}
+components:
+  responses:
+    BadRequest:
+      description: "Bad Request"
+      content:
+        application/json:
+          schema:
+            $ref: "./common.yaml#/components/schemas/BadRequestErrorResponseBody"


### PR DESCRIPTION
- extracting all 400 responses to common_responses.yaml
- in common_responses.yaml referring to common_response_schema.yaml for `BadRequestResponseBody` schema
- Making `error` field mandatory in `BadRequestResponseBody`