### PR TITLE
fixed order/id examples, orderStatus in parameters

### DIFF
--- a/in/specmatic/examples/store/api_order_v3.yaml
+++ b/in/specmatic/examples/store/api_order_v3.yaml
@@ -7,9 +7,9 @@ servers:
 paths:
   "/products/{id}":
     parameters:
-      - schema:
+      - name: id
+        schema:
           type: number
-        name: id
         in: path
         required: true
         examples:
@@ -107,7 +107,7 @@ paths:
         - name: type
           in: query
           schema:
-            $ref: "common.yaml#/components/schemas/ProductType"
+            $ref: "./common.yaml#/components/schemas/ProductType"
       responses:
         "200":
           description: List of products in the response
@@ -186,10 +186,10 @@ paths:
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
       parameters:
-        - schema:
-            type: number
+        - name: productid
           in: query
-          name: productid
+          schema:
+            type: number
           examples:
             200_OK:
               value: 10
@@ -197,11 +197,6 @@ paths:
           in: query
           schema:
             type: string
-            enum:
-            - book
-            - food
-            - gadget
-            - other
           examples:
             200_OK:
               value: fulfilled

--- a/in/specmatic/examples/store/api_order_v3.yaml
+++ b/in/specmatic/examples/store/api_order_v3.yaml
@@ -13,9 +13,9 @@ paths:
         in: path
         required: true
         examples:
-          GET_DETAILS:
+          GET_PRODUCT:
             value: 10
-          UPDATE_DETAILS:
+          UPDATE_PRODUCT:
             value: 10
           DELETE_PRODUCT:
             value: 20
@@ -32,7 +32,7 @@ paths:
               schema:
                 $ref: "./common.yaml#/components/schemas/Product"
               examples:
-                GET_DETAILS:
+                GET_PRODUCT:
                   value:
                     name: "XYZ Phone"
                     type: "gadget"
@@ -67,7 +67,7 @@ paths:
               schema:
                 type: string
               examples:
-                UPDATE_DETAILS:
+                UPDATE_PRODUCT:
                   value: "success"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
@@ -77,7 +77,7 @@ paths:
             schema:
               $ref: "./common.yaml#/components/schemas/Product"
             examples:
-              UPDATE_DETAILS:
+              UPDATE_PRODUCT:
                 value:
                   name: "XYZ Fone"
                   type: "gadget"
@@ -107,12 +107,7 @@ paths:
         - name: type
           in: query
           schema:
-            type: string
-            enum:
-              - gadget
-              - book
-              - food
-              - other
+            $ref: "common.yaml#/components/schemas/ProductType"
       responses:
         "200":
           description: List of products in the response
@@ -198,10 +193,15 @@ paths:
           examples:
             200_OK:
               value: 10
-        - schema:
-            type: string
+        - name: status
           in: query
-          name: status
+          schema:
+            type: string
+            enum:
+            - book
+            - food
+            - gadget
+            - other
           examples:
             200_OK:
               value: fulfilled
@@ -214,8 +214,12 @@ paths:
         in: path
         required: true
         examples:
-          DETAILS:
+          GET_ORDER:
             value: 10
+          UPDATE_ORDER:
+            value: 10
+          DELETE_ORDER:
+            value: 20
           INVALID_ID:
             value: 433
     get:
@@ -229,7 +233,7 @@ paths:
               schema:
                 $ref: "./common.yaml#/components/schemas/Order"
               examples:
-                DETAILS:
+                GET_ORDER:
                   value:
                     productid: 10
                     count: 2


### PR DESCRIPTION
The examples for the `id` parameter on the `/order/id` POST and DELETE endpoints were missing, causing tests to fail due to random `id` generation. Additionally, the schema for the `order-status` on the GET `/order` endpoint was incorrectly set to a string.

I have fixed the examples for the `id` parameter on `/order/id` and corrected the schema for the `status` parameter on the GET `/order` endpoint.