### PR TITLE
Add missing 400 and 415 responses to OpenAPI specs

### DIFF
--- a/io/specmatic/examples/store/openapi/api_order_v1.yaml
+++ b/io/specmatic/examples/store/openapi/api_order_v1.yaml
@@ -121,6 +121,8 @@ paths:
                     type: string
                   path:
                     type: string
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
       requestBody:
         required: true
         content:
@@ -206,6 +208,8 @@ paths:
                     type: string
                   path:
                     type: string
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
       requestBody:
         required: true
         content:
@@ -334,6 +338,8 @@ paths:
                     type: string
                   path:
                     type: string
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
       requestBody:
         required: true
         content:
@@ -510,6 +516,8 @@ paths:
                     type: string
                   path:
                     type: string
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
       requestBody:
         required: true
         content:
@@ -564,3 +572,10 @@ components:
       type: apiKey
       in: header
       name: Authenticate
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true

--- a/io/specmatic/examples/store/openapi/api_order_v3.yaml
+++ b/io/specmatic/examples/store/openapi/api_order_v3.yaml
@@ -82,6 +82,8 @@ paths:
                   value: "success"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
       requestBody:
         required: true
         content:
@@ -170,6 +172,8 @@ paths:
                     productId: 10
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
         "404":
           description: Not Found
           content:
@@ -223,6 +227,8 @@ paths:
                 $ref: "common.yml#/components/schemas/ProductId"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
   /orders:
     post:
       summary: POST /orders
@@ -257,6 +263,8 @@ paths:
                     id: 10
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
     get:
       summary: Search for orders
       operationId: get-orders
@@ -370,6 +378,8 @@ paths:
                   value: "success"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
       requestBody:
         required: true
         content:

--- a/io/specmatic/examples/store/openapi/api_order_v4.yaml
+++ b/io/specmatic/examples/store/openapi/api_order_v4.yaml
@@ -82,6 +82,8 @@ paths:
                   value: "success"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
       requestBody:
         required: true
         content:
@@ -170,6 +172,8 @@ paths:
                     productId: 10
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
         "404":
           description: Not Found
           content:
@@ -223,6 +227,8 @@ paths:
                 $ref: "common.yml#/components/schemas/ProductId"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
   /orders:
     post:
       summary: POST /orders
@@ -257,6 +263,8 @@ paths:
                     id: 10
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
     get:
       summary: Search for orders
       operationId: get-orders
@@ -341,6 +349,8 @@ paths:
                     - id: 30
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
       
   "/orders/{id}":
     parameters:
@@ -414,6 +424,8 @@ paths:
                   value: "success"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
       requestBody:
         required: true
         content:

--- a/io/specmatic/examples/store/openapi/api_order_v5.yaml
+++ b/io/specmatic/examples/store/openapi/api_order_v5.yaml
@@ -87,6 +87,8 @@ paths:
                   value: "success"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
         "404":
           $ref: "#/components/responses/NotFound"
     delete:
@@ -166,6 +168,8 @@ paths:
                     message: "Success"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
         "404":
           $ref: "#/components/responses/NotFound"
   /products:
@@ -251,6 +255,8 @@ paths:
                 $ref: "#/components/schemas/Id"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
   /orders:
@@ -296,6 +302,8 @@ paths:
                     id: 10
         "400":
           $ref: "#/components/responses/BadRequest"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
         "422":
           $ref: "#/components/responses/UnprocessableEntity"
     get:
@@ -395,6 +403,8 @@ paths:
                   value: "success"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
         "404":
           $ref: "#/components/responses/NotFound"
     delete:
@@ -545,7 +555,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponseBody"
-    
+    UnsupportedMediaType:
+      description: "Unsupported Media Type"
+      content:
+        application/json:
+          schema:
+            additionalProperties: true
     UnprocessableEntity:
       description: "Unprocessable Entity"
       content:

--- a/io/specmatic/examples/store/openapi/api_order_with_oauth_v3.yaml
+++ b/io/specmatic/examples/store/openapi/api_order_with_oauth_v3.yaml
@@ -80,6 +80,8 @@ paths:
                   value: "success"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
       requestBody:
         required: true
         content:
@@ -161,6 +163,8 @@ paths:
                 $ref: "common.yml#/components/schemas/ProductId"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
   /orders:
     post:
       summary: POST /orders
@@ -193,6 +197,8 @@ paths:
                     id: 10
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
     get:
       summary: Search for orders
       operationId: get-orders
@@ -300,6 +306,8 @@ paths:
                   value: "success"
         "400":
           $ref: "./common_responses.yml#/components/responses/BadRequest"
+        "415":
+          $ref: "./common_responses.yml#/components/responses/UnsupportedMediaType"
       requestBody:
         required: true
         content:

--- a/io/specmatic/examples/store/openapi/api_products_v1.yaml
+++ b/io/specmatic/examples/store/openapi/api_products_v1.yaml
@@ -51,6 +51,8 @@ paths:
               examples:
                 200_UPDATE:
                   $ref: "#/components/examples/200_UPDATE"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
   "/products":
     post:
       summary: Add a new product
@@ -79,6 +81,8 @@ paths:
               examples:
                 200_ADD:
                   $ref: "#/components/examples/200_ADD"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
 components:
   schemas:
     Product:
@@ -103,6 +107,13 @@ components:
           type: integer
       required:
         - id
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true
   examples:
     200_UPDATE:
       value:

--- a/io/specmatic/examples/store/openapi/api_products_v1.yaml
+++ b/io/specmatic/examples/store/openapi/api_products_v1.yaml
@@ -51,6 +51,8 @@ paths:
               examples:
                 200_UPDATE:
                   $ref: "#/components/examples/200_UPDATE"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "415":
           $ref: "#/components/responses/UnsupportedMediaType"
   "/products":
@@ -81,6 +83,8 @@ paths:
               examples:
                 200_ADD:
                   $ref: "#/components/examples/200_ADD"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "415":
           $ref: "#/components/responses/UnsupportedMediaType"
 components:
@@ -108,6 +112,12 @@ components:
       required:
         - id
   responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            additionalProperties: true
     UnsupportedMediaType:
       description: Unsupported Media Type
       content:

--- a/io/specmatic/examples/store/openapi/api_uuid_v1.yaml
+++ b/io/specmatic/examples/store/openapi/api_uuid_v1.yaml
@@ -60,6 +60,8 @@ paths:
                 $ref: '#/components/schemas/UuidResponse'
         '400':
           $ref: '#/components/responses/BadRequestResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
         '500':
           description: Server Error
   /uuid/{uuid_type}/{uuid}:
@@ -133,6 +135,8 @@ paths:
           description: Not Found
         '400':
           $ref: '#/components/responses/BadRequestResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
         '500':
           description: Server Error
 components:
@@ -143,6 +147,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
+    UnsupportedMediaTypeResponse:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true
   parameters:
     UuidTypeQuery:
       name: uuid_type

--- a/io/specmatic/examples/store/openapi/api_uuid_v1.yaml
+++ b/io/specmatic/examples/store/openapi/api_uuid_v1.yaml
@@ -135,8 +135,6 @@ paths:
           description: Not Found
         '400':
           $ref: '#/components/responses/BadRequestResponse'
-        '415':
-          $ref: '#/components/responses/UnsupportedMediaTypeResponse'
         '500':
           description: Server Error
 components:

--- a/io/specmatic/examples/store/openapi/common_response_schema.yml
+++ b/io/specmatic/examples/store/openapi/common_response_schema.yml
@@ -12,3 +12,5 @@ components:
           type: string
         message:
           type: string
+    UnsupportedMediaTypeErrorResponseBody:
+      additionalProperties: true

--- a/io/specmatic/examples/store/openapi/common_responses.yml
+++ b/io/specmatic/examples/store/openapi/common_responses.yml
@@ -6,3 +6,9 @@ components:
         application/json:
           schema:
             $ref: "./common_response_schema.yml#/components/schemas/BadRequestErrorResponseBody"
+    UnsupportedMediaType:
+      description: "Unsupported Media Type"
+      content:
+        application/json:
+          schema:
+            $ref: "./common_response_schema.yml#/components/schemas/UnsupportedMediaTypeErrorResponseBody"

--- a/io/specmatic/examples/store/openapi/data_pipeline/order_service/v1/create-order-service-v1.yaml
+++ b/io/specmatic/examples/store/openapi/data_pipeline/order_service/v1/create-order-service-v1.yaml
@@ -49,6 +49,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '503':
           description: Timeout
           content:
@@ -69,3 +71,10 @@ components:
           type: string
         message:
           type: string
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true

--- a/io/specmatic/examples/store/openapi/graphql_consumer_api_v1.yaml
+++ b/io/specmatic/examples/store/openapi/graphql_consumer_api_v1.yaml
@@ -61,6 +61,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '503':
           description: Timeout
           content:
@@ -149,3 +151,10 @@ components:
           type: string
         message:
           type: string
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true

--- a/io/specmatic/examples/store/openapi/graphql_consumer_api_v2.yaml
+++ b/io/specmatic/examples/store/openapi/graphql_consumer_api_v2.yaml
@@ -61,6 +61,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '503':
           description: Timeout
           content:
@@ -148,3 +150,10 @@ components:
           type: string
         path:
           type: string
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true

--- a/io/specmatic/examples/store/openapi/online_store_v1.yaml
+++ b/io/specmatic/examples/store/openapi/online_store_v1.yaml
@@ -57,6 +57,8 @@ paths:
               examples:
                 ADD_PRODUCTS_TO_STORE:
                   value: 2
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
     get:
       summary: Find matching products in given store
       parameters:
@@ -89,3 +91,11 @@ paths:
               examples:
                 FIND_PRODUCTS:
                   value: ["Powder", "Soap"]
+components:
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true

--- a/io/specmatic/examples/store/openapi/online_store_v1.yaml
+++ b/io/specmatic/examples/store/openapi/online_store_v1.yaml
@@ -57,6 +57,8 @@ paths:
               examples:
                 ADD_PRODUCTS_TO_STORE:
                   value: 2
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "415":
           $ref: "#/components/responses/UnsupportedMediaType"
     get:
@@ -91,8 +93,16 @@ paths:
               examples:
                 FIND_PRODUCTS:
                   value: ["Powder", "Soap"]
+        "400":
+          $ref: "#/components/responses/BadRequest"
 components:
   responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            additionalProperties: true
     UnsupportedMediaType:
       description: Unsupported Media Type
       content:

--- a/io/specmatic/examples/store/openapi/product_search_bff_api.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_api.yaml
@@ -34,6 +34,12 @@ paths:
                       name: 'XYZ Phone'
                       type: 'gadget'
                       inventory: 2
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
 components:
   schemas:
     Product:

--- a/io/specmatic/examples/store/openapi/product_search_bff_v3.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_v3.yaml
@@ -51,6 +51,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '503':
           description: Timeout
           content:
@@ -127,6 +129,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '503':
           description: Timeout
           content:
@@ -184,3 +188,10 @@ components:
           type: string
         path:
           type: string
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true

--- a/io/specmatic/examples/store/openapi/product_search_bff_v4.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_v4.yaml
@@ -213,6 +213,12 @@ paths:
                       productid: 1
                       count: 2
                       status: "completed"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
 components:
   schemas:
     Product:

--- a/io/specmatic/examples/store/openapi/product_search_bff_v4.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_v4.yaml
@@ -64,6 +64,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '503':
           description: Timeout
           content:
@@ -173,6 +175,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
         '503':
           description: Timeout
           content:
@@ -260,3 +264,10 @@ components:
           type: string
         message:
           type: string
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true

--- a/io/specmatic/examples/store/openapi/product_search_bff_v4.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_v4.yaml
@@ -213,12 +213,6 @@ paths:
                       productid: 1
                       count: 2
                       status: "completed"
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequest'
 components:
   schemas:
     Product:

--- a/io/specmatic/examples/store/openapi/product_search_bff_v5.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_v5.yaml
@@ -60,6 +60,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
   /findAvailableProducts:
     parameters:
       - schema:
@@ -181,6 +183,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
     get:
       summary: Retrieve orders
       description: Retrieve orders
@@ -393,3 +397,10 @@ components:
         message:
           type: string
           example: Validation failed
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true

--- a/io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
@@ -212,6 +212,12 @@ paths:
                       productid: 1
                       count: 2
                       status: "completed"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
   /monitor/{id}:
     get:
       summary: Retrieve monitor by ID

--- a/io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
@@ -212,12 +212,6 @@ paths:
                       productid: 1
                       count: 2
                       status: "completed"
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BadRequest'
   /monitor/{id}:
     get:
       summary: Retrieve monitor by ID

--- a/io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+++ b/io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
@@ -60,6 +60,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
   /findAvailableProducts:
     parameters:
       - schema:
@@ -175,6 +177,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
     get:
       summary: Retrieve orders
       description: Retrieve orders
@@ -367,3 +371,10 @@ components:
           type: string
         message:
           type: string
+  responses:
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            additionalProperties: true


### PR DESCRIPTION
Adds missing 400 and 415 responses across the OpenAPI examples under io/specmatic/examples/store/openapi, with these rules:
  - Skip operations marked WIP
  - Add 415 only for operations with requestBody
  - For 415, use a free-form object response body
  - For 400, reuse the existing 400 schema where the spec already defines one
  - If a spec had no prior 400 schema, use a free-form object response body
  - Keep shared-response specs wired through common response files where applicable
  - Keep standalone specs self-contained without introducing external refs

  It also updates shared response/schema files where needed to support the new reusable 415 responses.