### PR TITLE
[TEST] Non-breaking spec change to exercise backward compatibility CTRF report

### DIFF
--- a/.github/workflows/pull_request_merge_checks.yaml
+++ b/.github/workflows/pull_request_merge_checks.yaml
@@ -73,7 +73,6 @@ jobs:
         with:
           name: openapi-backward-compatibility-ctrf-report
           path: build/reports/specmatic/backward_compatibility/ctrf/*.json
-          retention-days: 5
 
       - name: Render OpenAPI backward compatibility CTRF report
         uses: ctrf-io/github-test-reporter@v1

--- a/.github/workflows/pull_request_merge_checks.yaml
+++ b/.github/workflows/pull_request_merge_checks.yaml
@@ -27,7 +27,6 @@ jobs:
             io/**/openapi/**/*.json
 
       - name: Save Specmatic license
-        if: steps.changed-openapi-files.outputs.any_changed == 'true'
         run: |
           mkdir -p ~/.specmatic
           echo "${{ secrets.SPECMATIC_LICENSE_KEY }}" > ~/.specmatic/specmatic-license.txt
@@ -44,12 +43,12 @@ jobs:
             examples validate --specs-dir=io/specmatic/examples/store/openapi
 
       - name: Run backward compatibility check
+        env:
+          SPECMATIC_LICENSE_CONTENT: ${{ secrets.SPECMATIC_LICENSE_KEY }}
         run: |
           docker run -v "$(pwd):/usr/src/app" \
-            -v ~/.specmatic:/root/.specmatic:ro \
-            -e GIT_CONFIG_COUNT=1 \
-            -e GIT_CONFIG_KEY_0=safe.directory \
-            -e GIT_CONFIG_VALUE_0='*' \
+            --user $(id -u):$(id -g) \
+            -e SPECMATIC_LICENSE_CONTENT \
             specmatic/enterprise \
             backward-compatibility-check --base-branch=origin/main
 

--- a/.github/workflows/pull_request_merge_checks.yaml
+++ b/.github/workflows/pull_request_merge_checks.yaml
@@ -63,7 +63,7 @@ jobs:
         if: steps.changed-openapi-files.outputs.any_changed == 'true'
         run: |
           docker run -v "$(pwd):/usr/src/app" \
-            --user $(id -u):$(id -g) \
+            -v ~/.specmatic:/root/.specmatic:ro \
             specmatic/specmatic \
             backward-compatibility-check --target-path=io/specmatic/examples/store/openapi --base-branch=origin/main
 

--- a/.github/workflows/pull_request_merge_checks.yaml
+++ b/.github/workflows/pull_request_merge_checks.yaml
@@ -63,7 +63,9 @@ jobs:
         if: steps.changed-openapi-files.outputs.any_changed == 'true'
         run: |
           docker run -v "$(pwd):/usr/src/app" \
-            -v ~/.specmatic:/root/.specmatic:ro \
+            --user $(id -u):$(id -g) \
+            -v ~/.specmatic:/specmatic:ro \
+            -e SPECMATIC_LICENSE_PATH=/specmatic/specmatic-license.txt \
             specmatic/specmatic \
             backward-compatibility-check --target-path=io/specmatic/examples/store/openapi --base-branch=origin/main
 

--- a/.github/workflows/pull_request_merge_checks.yaml
+++ b/.github/workflows/pull_request_merge_checks.yaml
@@ -17,85 +17,30 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get changed OpenAPI files
-        id: changed-openapi-files
-        uses: tj-actions/changed-files@v47
-        with:
-          files: |
-            io/**/openapi/**/*.yaml
-            io/**/openapi/**/*.yml
-            io/**/openapi/**/*.json
-
-      - name: Get changed GraphQLS files
-        id: changed-graphqls-files
-        uses: tj-actions/changed-files@v47
-        with:
-          files: |
-            io/**/graphql/**/*.graphqls
-            io/**/graphql/**/*.yaml
-
-      - name: Get changed gRPC files
-        id: changed-grpc-files
-        uses: tj-actions/changed-files@v47
-        with:
-          files: |
-            io/**/grpc/**/*.proto
-            io/**/grpc/**/*.json
-
       - name: Save Specmatic license
-        if: steps.changed-openapi-files.outputs.any_changed == 'true'
         run: |
           mkdir -p ~/.specmatic
           echo "${{ secrets.SPECMATIC_LICENSE_KEY }}" > ~/.specmatic/specmatic-license.txt
 
-      - name: Run Specmatic linter on OpenAPI specs
-        if: steps.changed-openapi-files.outputs.any_changed == 'true'
-        run: |
-          ./scripts/run-specmatic-openapi-linter.sh ${{ steps.changed-openapi-files.outputs.all_changed_files }}
-
-      - name: Validate OpenAPI examples
+      - name: Run backward compatibility check
         run: |
           docker run -v "$(pwd):/usr/src/app" \
-            specmatic/specmatic \
-            examples validate --specs-dir=io/specmatic/examples/store/openapi
+            -v ~/.specmatic:/root/.specmatic:ro \
+            -e GIT_CONFIG_COUNT=1 \
+            -e GIT_CONFIG_KEY_0=safe.directory \
+            -e GIT_CONFIG_VALUE_0='*' \
+            specmatic/enterprise \
+            backward-compatibility-check --base-branch=origin/main
 
-      - name: Run OpenAPI backward compatibility check on changed files
-        if: steps.changed-openapi-files.outputs.any_changed == 'true'
-        run: |
-          docker run -v "$(pwd):/usr/src/app" \
-            --user $(id -u):$(id -g) \
-            -e HOME=/tmp \
-            -v ~/.specmatic:/tmp/.specmatic \
-            specmatic/specmatic \
-            backward-compatibility-check --target-path=io/specmatic/examples/store/openapi --base-branch=origin/main
-
-      - name: Upload OpenAPI backward compatibility CTRF report
+      - name: Upload backward compatibility CTRF report
         uses: actions/upload-artifact@v6
-        if: always() && steps.changed-openapi-files.outputs.any_changed == 'true'
+        if: always() # Run even if the backward compatibility check fails
         with:
-          name: openapi-backward-compatibility-ctrf-report
+          name: backward-compatibility-ctrf-report
           path: build/reports/specmatic/backward_compatibility/ctrf/*.json
 
-      - name: Render OpenAPI backward compatibility CTRF report
+      - name: Render backward compatibility CTRF report
         uses: ctrf-io/github-test-reporter@v1
-        if: always() && steps.changed-openapi-files.outputs.any_changed == 'true'
+        if: always() # Run even if the backward compatibility check fails
         with:
           report-path: build/reports/specmatic/backward_compatibility/ctrf/*.json
-
-      - name: Run GraphQL backward compatibility check on changed files
-        if: steps.changed-graphqls-files.outputs.any_changed == 'true'
-        run: |
-          docker run -v "$(pwd):/usr/src/app" \
-            --user $(id -u):$(id -g) \
-            --env-file env.list \
-            specmatic/specmatic-graphql \
-            backward-compatibility-check --target-path=io/specmatic/examples/store/graphql --base-branch origin/main
-
-      - name: Run gRPC backward compatibility check on changed files
-        if: steps.changed-grpc-files.outputs.any_changed == 'true'
-        run: |
-          docker run -v "$(pwd):/usr/src/app" \
-            --user $(id -u):$(id -g) \
-            --env-file env.list \
-            specmatic/specmatic-grpc \
-            backward-compatibility-check --target-path=io/specmatic/examples/store/grpc --base-branch origin/main

--- a/.github/workflows/pull_request_merge_checks.yaml
+++ b/.github/workflows/pull_request_merge_checks.yaml
@@ -17,10 +17,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get changed OpenAPI files
+        id: changed-openapi-files
+        uses: tj-actions/changed-files@v47
+        with:
+          files: |
+            io/**/openapi/**/*.yaml
+            io/**/openapi/**/*.yml
+            io/**/openapi/**/*.json
+
       - name: Save Specmatic license
+        if: steps.changed-openapi-files.outputs.any_changed == 'true'
         run: |
           mkdir -p ~/.specmatic
           echo "${{ secrets.SPECMATIC_LICENSE_KEY }}" > ~/.specmatic/specmatic-license.txt
+
+      - name: Run Specmatic linter on OpenAPI specs
+        if: steps.changed-openapi-files.outputs.any_changed == 'true'
+        run: |
+          ./scripts/run-specmatic-openapi-linter.sh ${{ steps.changed-openapi-files.outputs.all_changed_files }}
+
+      - name: Validate OpenAPI examples
+        run: |
+          docker run -v "$(pwd):/usr/src/app" \
+            specmatic/specmatic \
+            examples validate --specs-dir=io/specmatic/examples/store/openapi
 
       - name: Run backward compatibility check
         run: |

--- a/.github/workflows/pull_request_merge_checks.yaml
+++ b/.github/workflows/pull_request_merge_checks.yaml
@@ -67,6 +67,20 @@ jobs:
             specmatic/specmatic \
             backward-compatibility-check --target-path=io/specmatic/examples/store/openapi --base-branch=origin/main
 
+      - name: Upload OpenAPI backward compatibility CTRF report
+        uses: actions/upload-artifact@v6
+        if: always() && steps.changed-openapi-files.outputs.any_changed == 'true'
+        with:
+          name: openapi-backward-compatibility-ctrf-report
+          path: build/reports/specmatic/backward_compatibility/ctrf/*.json
+          retention-days: 5
+
+      - name: Render OpenAPI backward compatibility CTRF report
+        uses: ctrf-io/github-test-reporter@v1
+        if: always() && steps.changed-openapi-files.outputs.any_changed == 'true'
+        with:
+          report-path: build/reports/specmatic/backward_compatibility/ctrf/*.json
+
       - name: Run GraphQL backward compatibility check on changed files
         if: steps.changed-graphqls-files.outputs.any_changed == 'true'
         run: |

--- a/.github/workflows/pull_request_merge_checks.yaml
+++ b/.github/workflows/pull_request_merge_checks.yaml
@@ -64,8 +64,8 @@ jobs:
         run: |
           docker run -v "$(pwd):/usr/src/app" \
             --user $(id -u):$(id -g) \
-            -v ~/.specmatic:/specmatic:ro \
-            -e SPECMATIC_LICENSE_PATH=/specmatic/specmatic-license.txt \
+            -e HOME=/tmp \
+            -v ~/.specmatic:/tmp/.specmatic \
             specmatic/specmatic \
             backward-compatibility-check --target-path=io/specmatic/examples/store/openapi --base-branch=origin/main
 

--- a/io/specmatic/examples/store/openapi/api_products_v1.yaml
+++ b/io/specmatic/examples/store/openapi/api_products_v1.yaml
@@ -95,6 +95,9 @@ components:
         cost:
           type: integer
           nullable: true
+        description:
+          type: string
+          nullable: true
     ProductId:
       title: Product Id
       type: object


### PR DESCRIPTION
**Throwaway test PR** — not for merge.

Adds an optional `description` property to `ProductDetails` in `api_products_v1.yaml`. This is a backward-compatible change that triggers the OpenAPI backward-compatibility check so the CTRF report is generated and rendered in the run summary.

Purpose: produce a successful CI run with the rendered CTRF report to screenshot for the docs (`central-contract-ci.png` in docs.specmatic.io).

Branched off `sahilm/bcc-report-ctrf-github-action` (PR #62) so it uses the updated workflow (license mounted into the backward-compat check).